### PR TITLE
Fix invalid line in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,10 +3,6 @@ version=0.1
 author=Pete Benson
 maintainer=Pete Benson
 sentence=A library to control a motorized ball valve using the TB6612FNG Toshiba H-bridge
-paragraph=Controls this valse I got from amazon.
-HSH-Flo Motorized Ball Valve 1/2" DN15 12VDC CR-05 FNPT SS304 Position Feedback Motorized Electric Ball Valve by HSH-Flo
-HSH-Flo Motorized Ball Valve 1/2" DN15 12VDC CR-05 FNPT SS304 Position Feedback Motorized Electric Ball Valve
-by HSH-Flo
-Link: http://a.co/eBQ5h8m
+paragraph=Controls this valse I got from amazon. HSH-Flo Motorized Ball Valve 1/2" DN15 12VDC CR-05 FNPT SS304 Position Feedback Motorized Electric Ball Valve by HSH-Flo. Link: http://a.co/eBQ5h8m
 category=Device Control
 url=https://github.com/slickrockpete/MotorValve


### PR DESCRIPTION
Each line in library.properties must either contain an '=', start with a #, or be whitespace. Installation of a library with an invalid line will cause compilation of any code (even if it doesn't #include the library) to fail:

Property line '...' in file ... is invalid

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format